### PR TITLE
fix: List object has not attribute 'price_currency'

### DIFF
--- a/apps/partner/strategy.py
+++ b/apps/partner/strategy.py
@@ -37,9 +37,10 @@ class Default(CoreDefault):
             return self.convert_currency(stockrecord, prices)
         return prices
 
-    def parent_pricing_policy(self, product, stockrecord):
-        prices = super().parent_pricing_policy(product, stockrecord)
-        if stockrecord:
+    def parent_pricing_policy(self, product, children_stock):
+        prices = super().parent_pricing_policy(product, children_stock)
+        if children_stock:
+            stockrecord = children_stock[0][1]  # take first record
             currency = self.get_currency()
             if currency == stockrecord.price_currency:
                 return prices


### PR DESCRIPTION
On catalogue:index and catalogue:category views
Error: "List object has not attribute 'price_currency'"
is thrown. Due to parent_pricing_policy method
not handling the stockrecord arg correctly.

I've fixed it.